### PR TITLE
Pin docutils to version 0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 six
 requests
-docutils=0.16
+docutils==0.16
 recommonmark~=0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 six
 requests
-docutils
+docutils=0.16
 recommonmark~=0.6.0


### PR DESCRIPTION
With docutils 0.17, when used in the GitLab EPJ documentation templates, HTML, PDF, and EPUB builds fail with

```
  Exception occurred:
    File "/usr/local/lib/python3.7/site-packages/sphinx/parsers.py", line 87, in parse
      inputstring, tab_width=document.settings.tab_width,
  AttributeError: 'Values' object has no attribute 'tab_width'
```